### PR TITLE
Remove redundant call to dvdcss_interface_2 

### DIFF
--- a/plugins/dvdcss/burn-dvdcss.c
+++ b/plugins/dvdcss/burn-dvdcss.c
@@ -95,9 +95,6 @@ brasero_dvdcss_library_init (BraseroPlugin *plugin)
 	if (!module)
 		goto error_doesnt_exist;
 
-	if (!g_module_symbol (module, "dvdcss_interface_2", &address))
-		goto error_version;
-
 	if (!g_module_symbol (module, "dvdcss_open", &address))
 		goto error_version;
 	dvdcss_open = address;


### PR DESCRIPTION
dvdcss_interface_2 was was dropped in libdvdcss 1.3.0. Removing this test allows brasero to work with both newer & older versions without any ill effects.
