### PR TITLE
fix: On UOS system, add the file failed.

### DIFF
--- a/src/brasero-project.c
+++ b/src/brasero-project.c
@@ -2125,7 +2125,7 @@ brasero_project_file_chooser_response_cb (GtkWidget *chooser,
 	action = gtk_action_group_get_action (project->priv->project_group, "Add");
 	gtk_action_set_sensitive (action, sensitive);
 
-	if (response != BRASERO_RESPONSE_ADD) {
+	if (response != BRASERO_RESPONSE_ADD && response != GTK_RESPONSE_ACCEPT) {
 		gtk_widget_destroy (chooser);
 		project->priv->chooser = NULL;
 		return;


### PR DESCRIPTION
the reason:
In brasero-project.c of the brasero project, line 2188 new a chooser dialog, line 2205 add a
"ADD" button, the response value is BRASERO_RESPONSE_ADD (1976), line 2128 add a judge, if the
value not equal the BRASERO_RESPONSE_ADD(1976), return directly.

On the UOS system, the offical file manager(dde-file-manager) of uos system will patch in gtk3.0,
hook the "gtk_file_chooser_dialog_new" function, the purpose is to create a file chooser dialog
with the same style as the UOS system(like windows).
When a third-party application uses the gtk_file_chooser_dialog_new function, it will show
the dde-file-manager's file chooser dialog, the dde-file-manager's dialog has cancel and open
button, not have the "ADD" button. when user clicked the open button, it will send a response
signal with a value of GTK_RESPONSE_ACCEPT(-3).

However, brasero judged that if the value of response is not equal to BRASERO_RESPONSE_ADD(1976)
, it will return. So on the UOS system, clicking add file fails.

the solution:
Modify the judgment. If it is not equal to BRASERO_RESPONSE_ADD or GTK_RESPONSE_ACCEPT,
then return.